### PR TITLE
allow server to write a fbs_<appid> cookie to the client

### DIFF
--- a/README
+++ b/README
@@ -48,4 +48,20 @@ shared login partial.
   <%= fb_login_and_redirect('<your URL here>', :perms => 'email,user_birthday') %>
 <% end %>
 
+
+Contributing
+============
+
+Unit tests use rspec and require the following environment configuration to run:
+rails 2.3.10
+rspec 1.3.1
+rspec-rails 1.3.3
+json 1.4.0
+
+Invoke tests on Mac/Linux by running 'rake spec' from this directory
+
+Invoke tests on Windows by running 'spec spec/' from this directory
+
+
+
 Copyright (c) 2010 Mike Mangino, released under the MIT license

--- a/lib/facebooker2/rails/controller.rb
+++ b/lib/facebooker2/rails/controller.rb
@@ -32,7 +32,6 @@ module Facebooker2
         
         #write the authentication params to a new cookie
         if !@_current_facebook_client.nil? 
-          logger.debug "writing new cookie"
           #we may have generated the signature based on the params in @facebook_params, and the expiration here is different
           
           set_fb_cookie(@_current_facebook_client.access_token, @_current_facebook_client.expiration, @_current_facebook_user.id, sig)
@@ -102,7 +101,6 @@ module Facebooker2
         end
         test_string += secret
         sig = Digest::MD5.hexdigest(test_string)
-        logger.debug "generated sig: " + sig
         return sig
       end
       

--- a/spec/spec.opts
+++ b/spec/spec.opts
@@ -1,0 +1,4 @@
+--colour
+--format progress
+--loadby mtime
+--reverse


### PR DESCRIPTION
As promised here is the patch to make facebooker2 write a fbs cookie to the client, following the pattern which the php facebook sdk uses.  This allows us to store auth information in this cookie instead of storing it in session, making the code to integrate with facebooker much simpler.  This should be the same cookie which the connect js sdk uses.

I also re-factored a few of the methods within controller.rb so that they weren't passing the app id all over the place unnecessarily.

I've got this code working in a sample app here:
https://github.com/clickonchris/facebooker2_canvas_example

As I am a self-taught rails developer I honestly welcome any feedback you have on this code

-Christopher G Johnson
