### PR TITLE
JS SDK initialization fix for IE

### DIFF
--- a/lib/facebooker2/rails/helpers/javascript.rb
+++ b/lib/facebooker2/rails/helpers/javascript.rb
@@ -13,9 +13,9 @@ module Facebooker2
         
         def fb_connect_async_js(app_id=Facebooker2.app_id,options={},&proc)
           opts = Hash.new.merge!(options)
-          cookie = opts[:cookie] || true
-          status = opts[:status] || true
-          xfbml = opts[:xfbml] || true
+          cookie = opts[:cookie].nil? ? true : opts[:cookie]
+          status = opts[:status].nil? ? true : opts[:status]
+          xfbml = opts[:xfbml].nil?   ? true : opts[:xfbml]
           channel_url = opts[:channel_url]
           lang = opts[:locale] || 'en_US'
           extra_js = capture(&proc) if block_given?

--- a/spec/helpers/javascript_spec.rb
+++ b/spec/helpers/javascript_spec.rb
@@ -1,0 +1,65 @@
+require "spec_helper"
+describe Facebooker2::Rails::Helpers::Javascript, :type=>:helper do
+  include Facebooker2::Rails::Helpers
+  describe "fb_connect_async_js" do
+    it "loads with defaults" do
+      js = fb_connect_async_js '12345'
+      js.should == <<-JAVASCRIPT   
+          <div id="fb-root"></div>
+          <script>
+            window.fbAsyncInit = function() {
+              FB.init({
+                appId  : '12345',
+                status : true, // check login status
+                cookie : true, // enable cookies to allow the server to access the session
+                
+                xfbml  : true  // parse XFBML
+              });
+              
+            };
+
+            (function() {
+              var e = document.createElement('script'); e.async = true;
+              e.src = document.location.protocol + '//connect.facebook.net/en_US/all.js';
+              document.getElementById('fb-root').appendChild(e);
+            }());
+          </script>
+      JAVASCRIPT
+    end
+    
+    it "disables cookies" do
+      js = fb_connect_async_js '12345', :cookie => false
+      js.include?("cookie : false").should be_true, js
+    end
+    
+    it "disables checking login status" do
+      js = fb_connect_async_js '12345', :status => false
+      js.include?("status : false").should be_true, js
+    end
+    
+    it "disables xfbml parsing" do
+      js = fb_connect_async_js '12345', :xfbml => false
+      js.include?("xfbml  : false").should be_true, js
+    end
+    
+    it "adds a channel url" do
+      js = fb_connect_async_js '12345', :channel_url => 'http://channel.url'
+      js.include?("channelUrl : 'http://channel.url'").should be_true, js
+    end
+    
+    it "changes the default locale" do
+      js = fb_connect_async_js '12345', :locale => 'fr_FR'
+      js.include?("//connect.facebook.net/fr_FR/all.js").should be_true, js
+    end
+
+    # Can't get this to work!
+    # it "adds extra js" do
+    #   helper.output_buffer = ""
+    #   fb_connect_async_js do
+    #     "FB.Canvas.setAutoResize();"
+    #   end
+    #   helper.output_buffer.include?("FB.Canvas.setAutoResize();").should be_true, helper.output_buffer
+    # end
+    
+  end
+end


### PR DESCRIPTION
The JS SDK initialization does not work properly with IE. See [this issue](https://github.com/mmangino/facebooker2/issues#issue/41) for details.

I made 3 changes to the way the JS SDK is initialized :
1. Mimic the way the JS SDK is initialized in the [Facebook documentation](http://developers.facebook.com/docs/reference/javascript/).
2. Fixed bug with the `channelUrl` option. The option hash was defaulting keys to `true` and that caused a bug with the `channelUrl` when this property was intented to be `nil`.
3. Added a `locale` option to change the language of the JS SDK.
