### PR TITLE
Rails 3.1 update_page 

### DIFF
--- a/lib/facebooker2/rails/helpers/facebook_connect.rb
+++ b/lib/facebooker2/rails/helpers/facebook_connect.rb
@@ -17,10 +17,15 @@ module Facebooker2
         #   => <fb:login-button onlogin="window.location.href = &quot;/other_page&quot;;" v="2">Login with Facebook</fb:login-button>
         #
         def fb_login_and_redirect(url, options = {})
-          js = update_page do |page|
-            page.redirect_to url
+          # Check if we got the update_page method (pre-Rails 3.1)
+          if respond_to? 'update_page'
+            js = update_page do |page|
+              page.redirect_to url
+            end
+          # Else use plain js
+          else
+            js = "window.location.href = '#{url}'"
           end
-
           text = options.delete(:text)
           
           #rails 3 only escapes non-html_safe strings, so get the raw string instead of the SafeBuffer


### PR DESCRIPTION
Add rails 3.1 support for Facebooker2::Rails::Helpers::FacebookConnect::fb_login_and_redirect to answer Issue #51
It lets facebooker2 still use update_page when it can be used (before 3.1rc4)

Just a lil thing : I didn't wrote any spec for it as my skills don't allow me to do so yet. Hope te patch may be useful if someone specs it (I'll maybe take a look at it if I have more time)
