### PR TITLE
Remove concat from fb_login

### DIFF
--- a/lib/facebooker2/rails/helpers/facebook_connect.rb
+++ b/lib/facebooker2/rails/helpers/facebook_connect.rb
@@ -35,7 +35,7 @@ module Facebooker2
         def fb_login(options = {},&proc)
            js = capture(&proc)
            text = options.delete(:text)
-           concat(content_tag("fb:login-button",text,options.merge(:onlogin=>js.to_str)))
+           content_tag("fb:login-button",text,options.merge(:onlogin=>js.to_str))
         end
         
         #


### PR DESCRIPTION
Remove concat that duplicates the content.
