### PR TITLE
Fix error when the Facebook cookie value is blank

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source "http://rubygems.org"
 source :gemcutter
 
 gemspec
+
+group :test do
+  gem 'test-unit', '1.2.3'
+end

--- a/lib/facebooker2/rails/controller.rb
+++ b/lib/facebooker2/rails/controller.rb
@@ -84,7 +84,7 @@ module Facebooker2
       end
       
       def fb_cookie?
-        !fb_cookie.nil?
+        !fb_cookie.blank?
       end
       
       def fb_cookie

--- a/spec/rails/controller_spec.rb
+++ b/spec/rails/controller_spec.rb
@@ -41,6 +41,20 @@ describe Facebooker2::Rails::Controller do
         controller.fb_cookie?.should be_false
       end
 
+      it "knows when there is a nil cookie value" do
+        controller.stub!(:cookies).and_return({
+          controller.fb_cookie_name => nil
+        })
+        controller.fb_cookie?.should be_false
+      end
+
+      it "knows when there is a blank cookie value" do
+        controller.stub!(:cookies).and_return({
+          controller.fb_cookie_name => ''
+        })
+        controller.fb_cookie?.should be_false
+      end
+
       it "gets the hash from the cookie" do
         controller.stub!(:cookies).and_return("fbs_12345"=>"param1=val1&param2=val2")
         controller.fb_cookie_hash.should == {"param1"=>"val1", "param2"=>"val2"}


### PR DESCRIPTION
Hi, small fix to prevent an error to raise.

Had an error when the Facebook cookie key was present, but the value was a blank String. Consequence of my commit is no more error, and user not authenticated, which seems kind of logical. Only drawback would be that when a user is unable to login to your app and report and issue, this [blank cookie value] issue would be more difficult to track.

Florent
