### PR TITLE
making fb_server_fbml html_safe  for rails 3

### DIFF
--- a/lib/facebooker2/rails/helpers/facebook_connect.rb
+++ b/lib/facebooker2/rails/helpers/facebook_connect.rb
@@ -46,10 +46,13 @@ module Facebooker2
           link_to_function text, function.to_str, *args
         end
         
-        def fb_server_fbml(style=nil,&proc)
+        def fb_server_fbml(style=nil, width=nil, &proc)
           style_string=" style=\"#{style}\"" if style
+          width_string=" width=\"#{width}\"" if width
           content = capture(&proc)
-          concat("<fb:serverFbml#{style_string}><script type='text/fbml'>#{content}</script></fb:serverFbml>")
+          output = "<fb:serverFbml#{style_string}#{width_string}><script type='text/fbml'><fb:fbml>#{content}</fb:fbml></script></fb:serverFbml>"
+          output = output.respond_to?(:html_safe) ? output.html_safe : output
+          concat(output)
         end
       end
     end

--- a/spec/helpers/facebook_connect_spec.rb
+++ b/spec/helpers/facebook_connect_spec.rb
@@ -30,24 +30,32 @@ describe Facebooker2::Rails::Helpers::FacebookConnect, :type=>:helper do
       fb_server_fbml do
         
       end
-      output_buffer.should == "<fb:serverFbml><script type='text/fbml'></script></fb:serverFbml>"
+      output_buffer.should == "<fb:serverFbml><script type='text/fbml'><fb:fbml></fb:fbml></script></fb:serverFbml>"
     end
     
     it "includes the content inside the block" do
       fb_server_fbml do
         "inner text"
       end
-      output_buffer.should == "<fb:serverFbml><script type='text/fbml'>inner text</script></fb:serverFbml>"      
+      output_buffer.should == "<fb:serverFbml><script type='text/fbml'><fb:fbml>inner text</fb:fbml></script></fb:serverFbml>"      
     end
     
     it "allows specifying style attributes" do
       fb_server_fbml "width: 750px;" do
-        
+
       end
-      output_buffer.should == "<fb:serverFbml style=\"width: 750px;\"><script type='text/fbml'></script></fb:serverFbml>"
-      
+      output_buffer.should == "<fb:serverFbml style=\"width: 750px;\"><script type='text/fbml'><fb:fbml></fb:fbml></script></fb:serverFbml>"
+
+    end
+
+    it "allows specifying width explicitly" do
+      fb_server_fbml nil, "600" do
+
+      end
+      output_buffer.should == "<fb:serverFbml width=\"600\"><script type='text/fbml'><fb:fbml></fb:fbml></script></fb:serverFbml>"
+
     end
   end
-  
+
 end
 


### PR DESCRIPTION
I've added functionality to make fb_server_fbml html_safe so it renders properly in rails 3.  I've also noticed that unless you explicitly set the width on fb_server_fbml facebook doesn't respect it, e.g. just in the style tag, so I added a param to the fb_server_fbml function for width.  I've updated the tests as well.
