### PR TITLE
gsub exception in Rails 3.2.3

### DIFF
--- a/lib/facebooker2/rails/controller.rb
+++ b/lib/facebooker2/rails/controller.rb
@@ -227,7 +227,7 @@ module Facebooker2
         sig,payload = fb_cookie.split('.')
         return unless fb_signed_request_sig_valid?(sig, payload)
         data = JSON.parse(base64_url_decode(payload))
-        authenticator = Mogli::Authenticator.new(Facebooker2.app_id, Facebooker2.secret, nil)
+        authenticator = Mogli::Authenticator.new(Facebooker2.app_id, Facebooker2.secret, '')
         client = Mogli::Client.create_from_code_and_authenticator(data["code"], authenticator)
         user = Mogli::User.new(:id=>data["user_id"])
         fb_sign_in_user_and_client(user, client)


### PR DESCRIPTION
In Facebooker2::Rails::Controller.oauth2_fetch_client_and_user_from_cookie you're passing nil which causes CGI.escape (within mogli) to throw an exception. This is resolved by passing an empty string instead.
