### PR TITLE
added .html_safe to second example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ shared login partial.
     <% current_facebook_user.fetch %>
       <%= "Welcome #{current_facebook_user.first_name} #{current_facebook_user.last_name}!" %>
       or 
-      <%= "Hello #{fb_name(current_facebook_user, :useyou => false)}!".html_safe %>
+      Welcome <%= fb_name(current_facebook_user, :useyou => false) %>!
       <%= fb_logout_link("Logout of fb", request.url) %><br />
     <% else
        # you must explicitly request permissions for facebook user fields.


### PR DESCRIPTION
without the html_safe rails converts the tag that fb_name creates into 'text' changing all the < and > to &lt; and &gt; etc, this stops it from being processed by the facebook js.
