### PR TITLE
Use base64_url_decode for decoding signed request JSON.

### DIFF
--- a/lib/facebooker2/rails/controller.rb
+++ b/lib/facebooker2/rails/controller.rb
@@ -121,7 +121,7 @@ module Facebooker2
       def fb_signed_request_json(encoded)
         chars_to_add = 4-(encoded.size % 4)
         encoded += ("=" * chars_to_add)
-        Base64.decode64(encoded)
+        base64_url_decode(encoded)
       end
       
       def facebook_params


### PR DESCRIPTION
https://developers.facebook.com/docs/authentication/signed_request/ states that the JSON part of the signed request is base64url encoded.

Without this fix, decoding signed requests containing _ or - characters leads to garbled strings and JSON parsing fails subsequently.
