### PR TITLE
changes to use latest javascript sdk and api version

### DIFF
--- a/lib/facebooker2/rails/helpers/javascript.rb
+++ b/lib/facebooker2/rails/helpers/javascript.rb
@@ -2,7 +2,7 @@ module Facebooker2
   module Rails
     module Helpers
       module Javascript
-        
+
         def fb_html_safe(str)
           if str.respond_to?(:html_safe)
             str.html_safe
@@ -10,13 +10,14 @@ module Facebooker2
             str
           end
         end
-        
+
         def fb_connect_async_js(app_id=Facebooker2.app_id,options={},&proc)
           opts = Hash.new.merge!(options)
           cookie = opts[:cookie].nil? ? true : opts[:cookie]
           status = opts[:status].nil? ? true : opts[:status]
           xfbml = opts[:xfbml].nil?   ? true : opts[:xfbml]
           music = opts[:music].nil?   ? false : opts[:music]
+          version = opts[:version]    ? opts[:version] : 'v2.0' #support version 2 or above.
           channel_url = opts[:channel_url]
           lang = opts[:locale] || 'en_US'
           extra_js = capture(&proc) if block_given?
@@ -28,6 +29,7 @@ module Facebooker2
                 appId  : '#{app_id}',
                 status : #{status}, // check login status
                 cookie : #{cookie}, // enable cookies to allow the server to access the session
+                version: '#{version}', //pass version for the new javascript sdk
                 #{"channelUrl : '#{channel_url}', // add channelURL to avoid IE redirect problems" unless channel_url.blank?}
                 #{"frictionlessRequests : true," if options[:frictionless_requests]}
                 oauth : true,
@@ -39,17 +41,17 @@ module Facebooker2
 
             (function() {
               var e = document.createElement('script'); e.async = true;
-              e.src = document.location.protocol + '//connect.facebook.net/#{lang}/all.js';
+              e.src = document.location.protocol + '//connect.facebook.net/#{lang}/sdk.js'; //facebook stops supporting versions < 2.0 from april 2015
               document.getElementById('fb-root').appendChild(e);
             }());
           </script>
           JAVASCRIPT
           escaped_js = fb_html_safe(js)
-          if block_given? 
+          if block_given?
            concat(escaped_js)
            #return the empty string, since concat returns the buffer and we don't want double output
            # from klochner
-           "" 
+           ""
           else
            escaped_js
           end

--- a/spec/helpers/javascript_spec.rb
+++ b/spec/helpers/javascript_spec.rb
@@ -27,30 +27,30 @@ describe Facebooker2::Rails::Helpers::Javascript, :type=>:helper do
     #      </script>
     #  JAVASCRIPT
     #end
-    
+
     it "disables cookies" do
       js = fb_connect_async_js '12345', :cookie => false
       js.include?("cookie : false").should be_true, js
     end
-    
+
     it "disables checking login status" do
       js = fb_connect_async_js '12345', :status => false
       js.include?("status : false").should be_true, js
     end
-    
+
     it "disables xfbml parsing" do
       js = fb_connect_async_js '12345', :xfbml => false
       js.include?("xfbml  : false").should be_true, js
     end
-    
+
     it "adds a channel url" do
       js = fb_connect_async_js '12345', :channel_url => 'http://channel.url'
       js.include?("channelUrl : 'http://channel.url'").should be_true, js
     end
-    
+
     it "changes the default locale" do
       js = fb_connect_async_js '12345', :locale => 'fr_FR'
-      js.include?("//connect.facebook.net/fr_FR/all.js").should be_true, js
+      js.include?("//connect.facebook.net/fr_FR/sdk.js").should be_true, js
     end
 
     it "supports oauth" do
@@ -58,13 +58,17 @@ describe Facebooker2::Rails::Helpers::Javascript, :type=>:helper do
       js = fb_connect_async_js '12345'
       js.include?("oauth").should be_true, js
     end
-    
+
     # to include support for frictionless app requests https://developers.facebook.com/blog/post/569/
     it "enables frictionless requests" do
       js = fb_connect_async_js '12345', :frictionless_requests => true
       js.include?("frictionlessRequests : true").should be_true, js
     end
-    
+
+    it "sets api version" do
+      js = fb_connect_async_js '12345', :version => 'v2.2'
+      js.include?("version: 'v2.2'").should be_true, js
+    end
 
     # Can't get this to work!
     # it "adds extra js" do
@@ -74,6 +78,6 @@ describe Facebooker2::Rails::Helpers::Javascript, :type=>:helper do
     #   end
     #   helper.output_buffer.include?("FB.Canvas.setAutoResize();").should be_true, helper.output_buffer
     # end
-    
+
   end
 end


### PR DESCRIPTION
Facebook will be stopping support for versions below 2.0.
"The current, latest version of the Graph API is v2.2. Apps calling v1.0 have until April 30, 2015 to upgrade to v2.0 or later." 

I updated the javascript helper to point to the latest javascript sdk api. more info here: https://developers.facebook.com/docs/javascript/quickstart/v2.2
